### PR TITLE
fixed subdivide leaf bug

### DIFF
--- a/abjadext/nauert/QGrid.py
+++ b/abjadext/nauert/QGrid.py
@@ -229,7 +229,7 @@ class QGrid:
         )
         if leaf.parent is not None:
             index = leaf.parent.index(leaf)
-            leaf.parent[index] = container
+            leaf.parent[index] = [container]
         # otherwise, our root node if just a QGridLeaf
         else:
             self._root_node = container


### PR DESCRIPTION
It seems that this one line should fix the bug in the `subdivide_leaf` method (and a number of bugs in the nauert extension). The reason for this fix is because of the `_set_items` method [here](https://github.com/josiah-wolf-oberholtzer/uqbar/blob/master/uqbar/containers/UniqueTreeList.py#L71), where the for loop seems to be iterating through the leaves of the container but not the container itself. In our `subdivide_leaf` algorithm, since we want to replace the old leaf with a new container, so the container itself (but not its leaves) should be attach to the old leaf's parent.

I ran pytest *locally* on the test modules and all the tests seemed to have passed. So this pull request should make most of the Nauert modules compatible with Abjad 3.1. I can still see there is a bug in the MeasurewiseQSchema, but that should probably be another pull request. Apologies in advance if my fix is not appropriate.