### PR TITLE
Made PitchedQEvents' attachments to survive the quantization

### DIFF
--- a/abjadext/nauert/gracehandlers.py
+++ b/abjadext/nauert/gracehandlers.py
@@ -94,10 +94,12 @@ class CollapsingGraceHandler(GraceHandler):
         Calls collapsing grace handler.
         """
         pitches = []
+        attachments = []
         for q_event in q_events:
             if isinstance(q_event, PitchedQEvent):
                 pitches.extend(q_event.pitches)
-        return tuple(pitches), None
+                attachments.extend(q_event.attachments)
+        return tuple(pitches), tuple(attachments), None
 
 
 class ConcatenatingGraceHandler(GraceHandler):
@@ -298,8 +300,10 @@ class ConcatenatingGraceHandler(GraceHandler):
 
         if isinstance(final_event, PitchedQEvent):
             pitches = final_event.pitches
+            attachments = final_event.attachments
         else:
             pitches = ()
+            attachments = None
 
         grace_events_list = list(grace_events)
         if self._discard_grace_rest:
@@ -318,11 +322,12 @@ class ConcatenatingGraceHandler(GraceHandler):
                         leaf = abjad.Chord(q_event.pitches, self.grace_duration)
                 else:
                     leaf = abjad.Rest(self.grace_duration)
+                abjad.annotate(leaf, "q_event_attachments", q_event.attachments)
                 grace_container.append(leaf)
         else:
             grace_container = None
 
-        return pitches, grace_container
+        return tuple(pitches), attachments, grace_container
 
     ### PUBLIC METHODS ###
 
@@ -389,8 +394,9 @@ class ConcatenatingGraceHandler(GraceHandler):
                     leaf = abjad.Note(q_event.pitches[0], self.grace_duration)
                 else:
                     leaf = abjad.Chord(q_event.pitches, self.grace_duration)
+                abjad.annotate(leaf, "q_event_attachments", q_event.attachments)
                 grace_container.append(leaf)
-        if grace_container:
+        if grace_container:  # TODO: check if the grace_container is empty?
             abjad.attach(grace_container, last_leaf)
 
     ### PUBLIC PROPERTIES ###
@@ -466,5 +472,5 @@ class DiscardingGraceHandler(GraceHandler):
         """
         q_event = q_events[-1]
         if isinstance(q_event, PitchedQEvent):
-            return q_event.pitches, None
-        return (), None
+            return tuple(q_event.pitches), tuple(q_event.attachments), None
+        return (), (), None

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,5 +21,8 @@ ignore_missing_imports = True
 [mypy-setuptools]
 ignore_missing_imports = True
 
+[mypy-six]
+ignore_missing_imports = True
+
 [mypy-uqbar.*]
 ignore_missing_imports = True

--- a/tests/test_QEventSequence_from_millisecond_pitch_attachment_tuples.py
+++ b/tests/test_QEventSequence_from_millisecond_pitch_attachment_tuples.py
@@ -1,0 +1,29 @@
+import abjad
+from abjadext import nauert
+
+
+def test_QEventSequence_from_millisecond_pitch_attachment_tuples_01():
+    durations = [100, 200, 100, 300, 350, 400, 600]
+    pitches = [0, None, None, [1, 4], None, 5, 7]
+    attachments = [("foo",), None, None, (6,), None, ("foobar",), ("foo", "bar")]
+    tuples = tuple(zip(durations, pitches, attachments))
+    q_events = nauert.QEventSequence.from_millisecond_pitch_attachment_tuples(tuples)
+    assert q_events == nauert.QEventSequence(
+        (
+            nauert.PitchedQEvent(abjad.Offset(0), (abjad.NamedPitch("c'"),), ("foo",)),
+            nauert.SilentQEvent(abjad.Offset(100, 1)),
+            nauert.PitchedQEvent(
+                abjad.Offset(400, 1),
+                (abjad.NamedPitch("cs'"), abjad.NamedPitch("e'")),
+                (6,),
+            ),
+            nauert.SilentQEvent(abjad.Offset(700, 1)),
+            nauert.PitchedQEvent(
+                abjad.Offset(1050, 1), (abjad.NamedPitch("f'"),), ("foobar",)
+            ),
+            nauert.PitchedQEvent(
+                abjad.Offset(1450, 1), (abjad.NamedPitch("g'"),), ("foo", "bar")
+            ),
+            nauert.TerminalQEvent(abjad.Offset(2050, 1)),
+        )
+    ), print(abjad.storage(q_events))

--- a/tests/test_Quantizer___call__.py
+++ b/tests/test_Quantizer___call__.py
@@ -2,6 +2,15 @@ import abjad
 from abjadext import nauert
 
 
+def assert_q_event_attachments(result, all_attachments):
+    for logical_tie, attachments in zip(
+        abjad.iterate(result).logical_ties(), all_attachments
+    ):
+        first_leaf = abjad.get.leaf(logical_tie, 0)
+        q_event_attachments = abjad.get.annotation(first_leaf, "q_event_attachments")
+        assert q_event_attachments == attachments, print(q_event_attachments)
+
+
 def test_Quantizer___call___01():
     milliseconds = [1500, 1500]
     q_events = nauert.QEventSequence.from_millisecond_durations(milliseconds)
@@ -420,9 +429,10 @@ def test_Quantizer___call___10():
     quantizer = nauert.Quantizer()
     durations = [1000, 1000, 1000, 2000, 1000, 1000, 500, 500]
     pitches = range(8)
+    all_attachments = [(x,) for x in pitches]
     pitches = [(x, x + 7) for x in pitches]
-    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
-        tuple(zip(durations, pitches))
+    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_attachment_tuples(
+        tuple(zip(durations, pitches, all_attachments))
     )
     grace_handler = nauert.ConcatenatingGraceHandler(
         replace_rest_with_final_grace_note=True
@@ -452,15 +462,17 @@ def test_Quantizer___call___10():
         }
         """
     ), print(string)
+    assert_q_event_attachments(result, all_attachments)
 
 
 def test_Quantizer___call___11():
     quantizer = nauert.Quantizer()
     durations = [250, 1250, 750, 1000, 250]
     pitches = range(5)
+    all_attachments = [(x,) for x in pitches]
     pitches = [(x, x + 7) for x in pitches]
-    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
-        tuple(zip(durations, pitches))
+    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_attachment_tuples(
+        tuple(zip(durations, pitches, all_attachments))
     )
     time_signature = abjad.TimeSignature((7, 8))
     search_tree = nauert.UnweightedSearchTree(
@@ -512,6 +524,7 @@ def test_Quantizer___call___11():
         }
         """
     ), print(string)
+    assert_q_event_attachments(result, all_attachments)
 
 
 def test_Quantizer___call___12():
@@ -520,8 +533,9 @@ def test_Quantizer___call___12():
     quantizer = nauert.Quantizer()
     durations = [457.14285, 814.1, 228.5714, 1440, 960]
     pitches = range(len(durations))
-    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
-        tuple(zip(durations, pitches))
+    all_attachments = [(x,) for x in pitches]
+    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_attachment_tuples(
+        tuple(zip(durations, pitches, all_attachments))
     )
     q_schema = nauert.MeasurewiseQSchema(
         search_tree=search_tree, time_signature=(7, 8), use_full_measure=True
@@ -570,6 +584,7 @@ def test_Quantizer___call___12():
         }
         """
     ), print(string)
+    assert_q_event_attachments(result, all_attachments)
 
 
 def test_Quantizer___call___13():
@@ -744,10 +759,12 @@ def test_Quantizer___call___16():
     durations = [1546, 578, 375, 589, 144, 918, 137]
     pitches = list(range(len(durations)))
     pitches[0] = None
+    all_attachments = [(x,) for x in pitches]
+    all_attachments[0] = None
 
     quantizer = nauert.Quantizer()
-    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
-        tuple(zip(durations, pitches))
+    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_attachment_tuples(
+        tuple(zip(durations, pitches, all_attachments))
     )
     definition = {"divisors": (2, 3, 5, 7), "max_depth": 2, "max_divisions": 2}
     search_tree = nauert.WeightedSearchTree(definition=definition)
@@ -803,3 +820,4 @@ def test_Quantizer___call___16():
         }
         """
     ), print(string)
+    assert_q_event_attachments(result, all_attachments)


### PR DESCRIPTION
This PR makes possible for PitchedQEvents' attachments to survive the quantization.
At the end of the quantization, the attachments can be found at the first leaf of each Logical Tie as an annotation labelled as `"q_event_attachments"`.