### PR TITLE
2021-10 update 1.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/abjadext/nauert/attackpointoptimizers.py
+++ b/abjadext/nauert/attackpointoptimizers.py
@@ -312,8 +312,8 @@ class NaiveAttackPointOptimizer(AttackPointOptimizer):
         """
         Calls naive attack-point optimizer.
         """
-        for logical_tie in abjad.iterate(argument).logical_ties(
-            grace=False, reverse=True
+        for logical_tie in abjad.iterate.logical_ties(
+            argument, grace=False, reverse=True
         ):
             sub_logical_ties = []
             current_sub_logical_tie = []

--- a/abjadext/nauert/qeventproxy.py
+++ b/abjadext/nauert/qeventproxy.py
@@ -107,7 +107,7 @@ class QEventProxy:
         values = []
         if self.offset:
             values.append(self.offset)
-        return abjad.FormatSpecification(storage_format_args_values=values)
+        return abjad.FormatSpecification(storage_format_args_values=tuple(values))
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjadext/nauert/qeventproxy.py
+++ b/abjadext/nauert/qeventproxy.py
@@ -90,7 +90,7 @@ class QEventProxy:
         Interprets `''` equal to `'storage'`.
         """
         if format_specification in ("", "storage"):
-            return abjad.StorageFormatManager(self).get_storage_format()
+            return abjad.storage(self)
         return str(self)
 
     def __hash__(self) -> int:
@@ -107,7 +107,7 @@ class QEventProxy:
         values = []
         if self.offset:
             values.append(self.offset)
-        return abjad.FormatSpecification(client=self, storage_format_args_values=values)
+        return abjad.FormatSpecification(storage_format_args_values=values)
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjadext/nauert/qevents.py
+++ b/abjadext/nauert/qevents.py
@@ -40,7 +40,7 @@ class QEvent(abc.ABC):
         """
         Formats object.
         """
-        return abjad.StorageFormatManager(self).get_storage_format()
+        return abjad.storage(self)
 
     def __lt__(self, argument) -> bool:
         """
@@ -56,18 +56,18 @@ class QEvent(abc.ABC):
         """
         Gets interpreter representation.
         """
-        return abjad.StorageFormatManager(self).get_repr_format()
+        return abjad.format.get_repr(self)
 
     ### PRIVATE METHODS ###
 
-    def _get_format_specification(self) -> abjad.FormatSpecification:
-        agent = abjad.StorageFormatManager(self)
-        names = agent.signature_keyword_names
+    def _get_format_specification(self):
+        result = abjad.format._inspect_signature(self)
+        signature_keyword_names = result[1]
+        names = list(signature_keyword_names)
         for name in ("attachments",):
             if not getattr(self, name, None) and name in names:
                 names.remove(name)
         return abjad.FormatSpecification(
-            client=self,
             repr_is_indented=False,
             storage_format_keyword_names=names,
         )

--- a/abjadext/nauert/qeventsequence.py
+++ b/abjadext/nauert/qeventsequence.py
@@ -163,7 +163,7 @@ class QEventSequence:
 
         """
         if format_specification in ("", "storage"):
-            return abjad.StorageFormatManager(self).get_storage_format()
+            return abjad.storage(self)
         return str(self)
 
     @typing.overload
@@ -214,7 +214,6 @@ class QEventSequence:
         if self.sequence:
             values.append(self.sequence)
         return abjad.FormatSpecification(
-            client=self,
             storage_format_args_values=values,
             storage_format_keyword_names=[],
         )

--- a/abjadext/nauert/qeventsequence.py
+++ b/abjadext/nauert/qeventsequence.py
@@ -214,8 +214,8 @@ class QEventSequence:
         if self.sequence:
             values.append(self.sequence)
         return abjad.FormatSpecification(
-            storage_format_args_values=values,
-            storage_format_keyword_names=[],
+            storage_format_args_values=tuple(values),
+            storage_format_keyword_names=None,
         )
 
     ### PUBLIC PROPERTIES ###

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -349,13 +349,8 @@ class QGrid:
 
     ### PRIVATE METHODS ###
 
-<<<<<<< HEAD
-    def _get_format_specification(self) -> abjad.FormatSpecification:
-        return abjad.FormatSpecification(client=self)
-=======
     def _get_format_specification(self):
         return abjad.FormatSpecification()
->>>>>>> cc0562e (2021-10 update 1.)
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -78,14 +78,15 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
 
     ### PRIVATE METHODS ###
 
-    def _get_format_specification(self) -> abjad.FormatSpecification:
-        agent = abjad.StorageFormatManager(self)
-        names = agent.signature_names
+    def _get_format_specification(self):
+        result = abjad.format._inspect_signature(self)
+        signature_positional_names = result[0]
+        signature_keyword_names = result[1]
+        names = list(signature_positional_names) + list(signature_keyword_names)
         template_names = names[:]
         if "q_event_proxies" in names and not self.q_event_proxies:
             names.remove("q_event_proxies")
         return abjad.FormatSpecification(
-            client=self,
             repr_is_indented=True,
             storage_format_keyword_names=names,
             template_names=template_names,
@@ -280,7 +281,7 @@ class QGrid:
         """
         result = self.root_node(beatspan)
         result_logical_ties = [
-            logical_tie for logical_tie in abjad.iterate(result).logical_ties()
+            logical_tie for logical_tie in abjad.iterate.logical_ties(result)
         ]
         assert len(result_logical_ties) == len(self.leaves[:-1])
         for logical_tie, q_grid_leaf in zip(result_logical_ties, self.leaves[:-1]):
@@ -328,7 +329,7 @@ class QGrid:
 
         Returns string.
         """
-        return abjad.StorageFormatManager(self).get_storage_format()
+        return abjad.storage(self)
 
     def __hash__(self) -> int:
         """
@@ -344,12 +345,17 @@ class QGrid:
         """
         Gets interpreter representation.
         """
-        return abjad.StorageFormatManager(self).get_repr_format()
+        return abjad.format.get_repr(self)
 
     ### PRIVATE METHODS ###
 
+<<<<<<< HEAD
     def _get_format_specification(self) -> abjad.FormatSpecification:
         return abjad.FormatSpecification(client=self)
+=======
+    def _get_format_specification(self):
+        return abjad.FormatSpecification()
+>>>>>>> cc0562e (2021-10 update 1.)
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjadext/nauert/qschemaitems.py
+++ b/abjadext/nauert/qschemaitems.py
@@ -53,7 +53,7 @@ class QSchemaItem(abc.ABC):
         equal to `'storage'`.
         """
         if format_specification in ("", "storage"):
-            return abjad.StorageFormatManager(self).get_storage_format()
+            return abjad.storage(self)
         return str(self)
 
     ### PUBLIC PROPERTIES ###

--- a/abjadext/nauert/qschemas.py
+++ b/abjadext/nauert/qschemas.py
@@ -434,8 +434,8 @@ class BeatwiseQSchema(QSchema):
 
     def _get_format_specification(self) -> abjad.FormatSpecification:
         return abjad.FormatSpecification(
-            storage_format_args_values=self.items or (),
-            storage_format_keyword_names=["beatspan", "search_tree", "tempo"],
+            storage_format_args_values=tuple(self.items) or (),
+            storage_format_keyword_names=("beatspan", "search_tree", "tempo"),
         )
 
     ### PUBLIC PROPERTIES ###
@@ -703,13 +703,13 @@ class MeasurewiseQSchema(QSchema):
 
     def _get_format_specification(self) -> abjad.FormatSpecification:
         return abjad.FormatSpecification(
-            storage_format_args_values=self.items or (),
-            storage_format_keyword_names=[
+            storage_format_args_values=tuple(self.items) or (),
+            storage_format_keyword_names=(
                 "search_tree",
                 "tempo",
                 "time_signature",
                 "use_full_measure",
-            ],
+            ),
         )
 
     ### PUBLIC PROPERTIES ###

--- a/abjadext/nauert/qschemas.py
+++ b/abjadext/nauert/qschemas.py
@@ -98,7 +98,7 @@ class QSchema(abc.ABC):
         equal to `'storage'`.
         """
         if format_specification in ("", "storage"):
-            return abjad.StorageFormatManager(self).get_storage_format()
+            return abjad.storage(self)
         return str(self)
 
     def __getitem__(self, argument: int) -> dict:
@@ -434,7 +434,6 @@ class BeatwiseQSchema(QSchema):
 
     def _get_format_specification(self) -> abjad.FormatSpecification:
         return abjad.FormatSpecification(
-            client=self,
             storage_format_args_values=self.items or (),
             storage_format_keyword_names=["beatspan", "search_tree", "tempo"],
         )
@@ -704,7 +703,6 @@ class MeasurewiseQSchema(QSchema):
 
     def _get_format_specification(self) -> abjad.FormatSpecification:
         return abjad.FormatSpecification(
-            client=self,
             storage_format_args_values=self.items or (),
             storage_format_keyword_names=[
                 "search_tree",

--- a/abjadext/nauert/qtargetitems.py
+++ b/abjadext/nauert/qtargetitems.py
@@ -151,7 +151,7 @@ class QTargetBeat(QTargetItem):
         equal to `'storage'`.
         """
         if format_specification in ("", "storage"):
-            return abjad.StorageFormatManager(self).get_storage_format()
+            return abjad.storage(self)
         return str(self)
 
     ### PUBLIC PROPERTIES ###
@@ -455,7 +455,7 @@ class QTargetMeasure(QTargetItem):
         equal to `'storage'`.
         """
         if format_specification in ("", "storage"):
-            return abjad.StorageFormatManager(self).get_storage_format()
+            return abjad.storage(self)
         return str(self)
 
     ### PUBLIC PROPERTIES ###

--- a/abjadext/nauert/qtargets.py
+++ b/abjadext/nauert/qtargets.py
@@ -173,7 +173,7 @@ class QTarget(abc.ABC):
         self, grace_handler: GraceHandler, voice: typing.Optional[abjad.Voice] = None
     ) -> typing.List[typing.Optional[tuple]]:
         all_q_event_attachments: typing.List[typing.Optional[tuple]] = []
-        for leaf in abjad.iterate(voice).leaves():
+        for leaf in abjad.iterate.leaves(voice):
             if leaf._has_indicator(dict):
                 annotation = leaf._get_indicator(dict)
                 q_events = annotation["q_events"]

--- a/abjadext/nauert/qtargets.py
+++ b/abjadext/nauert/qtargets.py
@@ -153,7 +153,7 @@ class QTarget(abc.ABC):
         all_attachments: typing.Sequence[typing.Optional[tuple]],
     ):
         logical_tie_list = list(
-            abjad.iterate(voice).logical_ties(grace=False, pitched=True)
+            abjad.iterate.logical_ties(voice, grace=False, pitched=True)
         )
         assert len(logical_tie_list) == len(all_attachments)
         for logical_tie, attachments in zip(logical_tie_list, all_attachments):

--- a/abjadext/nauert/quantizationjob.py
+++ b/abjadext/nauert/quantizationjob.py
@@ -126,7 +126,7 @@ class QuantizationJob:
         """
         Formats object.
         """
-        return abjad.StorageFormatManager(self).get_storage_format()
+        return abjad.storage(self)
 
     def __hash__(self) -> int:
         """
@@ -138,8 +138,8 @@ class QuantizationJob:
 
     ### PRIVATE METHODS ###
 
-    def _get_format_specification(self) -> abjad.FormatSpecification:
-        return abjad.FormatSpecification(client=self)
+    def _get_format_specification(self):
+        return abjad.FormatSpecification()
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjadext/nauert/searchtrees.py
+++ b/abjadext/nauert/searchtrees.py
@@ -63,7 +63,7 @@ class SearchTree(abc.ABC):
         """
         Formats object.
         """
-        return abjad.StorageFormatManager(self).get_storage_format()
+        return abjad.storage(self)
 
     def __hash__(self) -> int:
         """
@@ -77,7 +77,7 @@ class SearchTree(abc.ABC):
         """
         Gets interpreter representation.
         """
-        return abjad.StorageFormatManager(self).get_repr_format()
+        return abjad.format.get_repr(self)
 
     ### PRIVATE METHODS ###
 
@@ -133,8 +133,8 @@ class SearchTree(abc.ABC):
         combinations = [tuple(_) for _ in combinations]
         return tuple(tuple(zip(indices, combo)) for combo in combinations)
 
-    def _get_format_specification(self) -> abjad.FormatSpecification:
-        return abjad.FormatSpecification(client=self)
+    def _get_format_specification(self):
+        return abjad.FormatSpecification()
 
     @abc.abstractmethod
     def _is_valid_definition(self, definition: dict) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ if __name__ == "__main__":
         classifiers=[
             "Development Status :: 3 - Alpha",
             "License :: OSI Approved :: GNU General Public License (GPL)",
-            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: Implementation :: CPython",
             "Topic :: Artistic Software",
         ],

--- a/tests/test_Quantizer___call__.py
+++ b/tests/test_Quantizer___call__.py
@@ -4,7 +4,7 @@ from abjadext import nauert
 
 def assert_q_event_attachments(result, all_attachments):
     for logical_tie, attachments in zip(
-        abjad.iterate(result).logical_ties(pitched=True), all_attachments
+        abjad.iterate.logical_ties(result, pitched=True), all_attachments
     ):
         first_leaf = abjad.get.leaf(logical_tie, 0)
         q_event_attachments = abjad.get.annotation(first_leaf, "q_event_attachments")


### PR DESCRIPTION
OLD: abjad.iterate(argument).leaves()
NEW: abjad.iterate.leaves(argument)

OLD: abjad.format.make_repr()
NEW: abjad.format.get_repr()

* Incremented Python to 3.9, or later