### PR TITLE
Dev/update tests

### DIFF
--- a/abjadext/nauert/qschemaitems.py
+++ b/abjadext/nauert/qschemaitems.py
@@ -95,10 +95,7 @@ class BeatwiseQSchemaItem(QSchemaItem):
         >>> string = abjad.storage(q_schema_item)
         >>> print(string)
         nauert.BeatwiseQSchemaItem(
-            tempo=abjad.MetronomeMark(
-                reference_duration=abjad.Duration(1, 4),
-                units_per_minute=60,
-                ),
+            tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
             )
 
     ..  container:: example
@@ -167,10 +164,7 @@ class MeasurewiseQSchemaItem(QSchemaItem):
         >>> string = abjad.storage(q_schema_item)
         >>> print(string)
         nauert.MeasurewiseQSchemaItem(
-            tempo=abjad.MetronomeMark(
-                reference_duration=abjad.Duration(1, 4),
-                units_per_minute=60,
-                ),
+            tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
             )
 
     ..  container:: example
@@ -181,7 +175,7 @@ class MeasurewiseQSchemaItem(QSchemaItem):
         >>> string = abjad.storage(q_schema_item)
         >>> print(string)
         nauert.MeasurewiseQSchemaItem(
-            time_signature=abjad.TimeSignature((6, 8)),
+            time_signature=TimeSignature(pair=(6, 8), hide=False, partial=None),
             )
 
     ..  container:: example

--- a/abjadext/nauert/qschemas.py
+++ b/abjadext/nauert/qschemas.py
@@ -227,10 +227,7 @@ class BeatwiseQSchema(QSchema):
                     13: None,
                     },
                 ),
-            tempo=abjad.MetronomeMark(
-                reference_duration=abjad.Duration(1, 4),
-                units_per_minute=60,
-                ),
+            tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
             )
 
     ..  container:: example
@@ -515,11 +512,8 @@ class MeasurewiseQSchema(QSchema):
                     13: None,
                     },
                 ),
-            tempo=abjad.MetronomeMark(
-                reference_duration=abjad.Duration(1, 4),
-                units_per_minute=60,
-                ),
-            time_signature=abjad.TimeSignature((4, 4)),
+            tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
+            time_signature=TimeSignature(pair=(4, 4), hide=False, partial=None),
             use_full_measure=False,
             )
 
@@ -628,28 +622,28 @@ class MeasurewiseQSchema(QSchema):
         >>> q_schema = nauert.MeasurewiseQSchema(settings)
 
         >>> q_schema[0]["time_signature"]
-        TimeSignature((4, 4))
+        TimeSignature(pair=(4, 4), hide=False, partial=None)
 
         >>> q_schema[1]["time_signature"]
-        TimeSignature((4, 4))
+        TimeSignature(pair=(4, 4), hide=False, partial=None)
 
         >>> q_schema[2]["time_signature"]
-        TimeSignature((7, 32))
+        TimeSignature(pair=(7, 32), hide=False, partial=None)
 
         >>> q_schema[3]["time_signature"]
-        TimeSignature((7, 32))
+        TimeSignature(pair=(7, 32), hide=False, partial=None)
 
         >>> q_schema[4]["time_signature"]
-        TimeSignature((3, 4))
+        TimeSignature(pair=(3, 4), hide=False, partial=None)
 
         >>> q_schema[5]["time_signature"]
-        TimeSignature((3, 4))
+        TimeSignature(pair=(3, 4), hide=False, partial=None)
 
         >>> q_schema[6]["time_signature"]
-        TimeSignature((5, 8))
+        TimeSignature(pair=(5, 8), hide=False, partial=None)
 
         >>> q_schema[1000]["time_signature"]
-        TimeSignature((5, 8))
+        TimeSignature(pair=(5, 8), hide=False, partial=None)
 
     ..  container:: example
 
@@ -746,7 +740,7 @@ class MeasurewiseQSchema(QSchema):
             ...     time_signature=abjad.TimeSignature((3, 4))
             ... )
             >>> q_schema.time_signature
-            TimeSignature((3, 4))
+            TimeSignature(pair=(3, 4), hide=False, partial=None)
 
         ..  container:: example
 
@@ -765,7 +759,7 @@ class MeasurewiseQSchema(QSchema):
 
             >>> q_schema = nauert.MeasurewiseQSchema(settings)
             >>> q_schema.time_signature
-            TimeSignature((4, 4))
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
         """
         return self._time_signature
 

--- a/abjadext/nauert/qtargetitems.py
+++ b/abjadext/nauert/qtargetitems.py
@@ -55,10 +55,7 @@ class QTargetBeat(QTargetItem):
                 definition={   3: None,
                     },
                 ),
-            tempo=abjad.MetronomeMark(
-                reference_duration=abjad.Duration(1, 4),
-                units_per_minute=56,
-                ),
+            tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=56, textual_indication=None, custom_markup=None, decimal=None, hide=False),
             )
 
     Not composer-safe.
@@ -294,7 +291,7 @@ class QTargetBeat(QTargetItem):
         ...     )
 
         >>> q_target_beat.tempo
-        MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=56)
+        MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=56, textual_indication=None, custom_markup=None, decimal=None, hide=False)
 
         """
         return self._tempo
@@ -324,14 +321,12 @@ class QTargetMeasure(QTargetItem):
         nauert.QTargetMeasure(
             offset_in_ms=abjad.Offset((1000, 1)),
             search_tree=nauert.UnweightedSearchTree(
-                definition={   2: None,
+                definition={
+                    2: None,
                     },
                 ),
-            time_signature=abjad.TimeSignature((4, 4)),
-            tempo=abjad.MetronomeMark(
-                reference_duration=abjad.Duration(1, 4),
-                units_per_minute=60,
-                ),
+            time_signature=TimeSignature(pair=(4, 4), hide=False, partial=None),
+            tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
             use_full_measure=False,
             )
 
@@ -487,49 +482,41 @@ class QTargetMeasure(QTargetItem):
                 beatspan=abjad.Duration(1, 4),
                 offset_in_ms=abjad.Offset((1000, 1)),
                 search_tree=nauert.UnweightedSearchTree(
-                    definition={   2: None,
+                    definition={
+                        2: None,
                         },
                     ),
-                tempo=abjad.MetronomeMark(
-                    reference_duration=abjad.Duration(1, 4),
-                    units_per_minute=60,
-                    ),
+                tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
                 )
             nauert.QTargetBeat(
                 beatspan=abjad.Duration(1, 4),
                 offset_in_ms=abjad.Offset((2000, 1)),
                 search_tree=nauert.UnweightedSearchTree(
-                    definition={   2: None,
+                    definition={
+                        2: None,
                         },
                     ),
-                tempo=abjad.MetronomeMark(
-                    reference_duration=abjad.Duration(1, 4),
-                    units_per_minute=60,
-                    ),
+                tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
                 )
             nauert.QTargetBeat(
                 beatspan=abjad.Duration(1, 4),
                 offset_in_ms=abjad.Offset((3000, 1)),
                 search_tree=nauert.UnweightedSearchTree(
-                    definition={   2: None,
+                    definition={
+                        2: None,
                         },
                     ),
-                tempo=abjad.MetronomeMark(
-                    reference_duration=abjad.Duration(1, 4),
-                    units_per_minute=60,
-                    ),
+                tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
                 )
             nauert.QTargetBeat(
                 beatspan=abjad.Duration(1, 4),
                 offset_in_ms=abjad.Offset((4000, 1)),
                 search_tree=nauert.UnweightedSearchTree(
-                    definition={   2: None,
+                    definition={
+                        2: None,
                         },
                     ),
-                tempo=abjad.MetronomeMark(
-                    reference_duration=abjad.Duration(1, 4),
-                    units_per_minute=60,
-                    ),
+                tempo=MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False),
                 )
 
         """
@@ -626,7 +613,7 @@ class QTargetMeasure(QTargetItem):
             ...     )
 
             >>> q_target_measure.tempo
-            MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60)
+            MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=60, textual_indication=None, custom_markup=None, decimal=None, hide=False)
 
         """
         return self._tempo
@@ -650,7 +637,7 @@ class QTargetMeasure(QTargetItem):
             ...     )
 
             >>> q_target_measure.time_signature
-            TimeSignature((4, 4))
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
 
         """
         return self._time_signature


### PR DESCRIPTION
This PR updates the doctest of `abjad-ext-nauert` to reflect the changes in the representation of `abjad.Duration`, `abjad.MetronomeMark`, and `abjad.TimeSignature`.