### PR TITLE
Deprecating abjad.Selection class and updating the type of Chord.written_pitches

### DIFF
--- a/abjadext/nauert/qeventsequence.py
+++ b/abjadext/nauert/qeventsequence.py
@@ -444,10 +444,7 @@ class QEventSequence:
     @classmethod
     def from_tempo_scaled_leaves(
         class_,
-        leaves: typing.Union[
-            abjad.Selection,
-            typing.Sequence[typing.Union[abjad.Component, abjad.Selection]],
-        ],
+        leaves: list | typing.Sequence[abjad.Component | list],
         tempo: typing.Optional[
             typing.Union[
                 abjad.MetronomeMark,

--- a/abjadext/nauert/qtargets.py
+++ b/abjadext/nauert/qtargets.py
@@ -183,7 +183,7 @@ class QTarget(abc.ABC):
                     new_leaf = abjad.Rest(leaf)
                 elif 1 < len(pitches):
                     new_leaf = abjad.Chord(leaf)
-                    new_leaf.written_pitches = abjad.PitchSegment(pitches)
+                    new_leaf.written_pitches = pitches
                 else:
                     new_leaf = abjad.Note(leaf)
                     new_leaf.written_pitch = pitches[0]


### PR DESCRIPTION
This PR
- replaces `abjad.Selection` by `list`
- removes the casting of written pitches from tuple to abjad.PitchSegment