### PR TITLE
Update #2 for Abjad 3.17.

### DIFF
--- a/abjadext/nauert/attackpointoptimizers.py
+++ b/abjadext/nauert/attackpointoptimizers.py
@@ -40,12 +40,12 @@ class MeasurewiseAttackPointOptimizer(AttackPointOptimizer):
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8 g'8 a'8 b'8 c''8")
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> source_tempo = abjad.MetronomeMark((1, 4), 60)
+        >>> source_tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> q_events = nauert.QEventSequence.from_tempo_scaled_leaves(
         ...     staff[:],
         ...     tempo=source_tempo,
         ... )
-        >>> target_tempo = abjad.MetronomeMark((1, 4), 54)
+        >>> target_tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 54)
         >>> q_schema = nauert.MeasurewiseQSchema(
         ...     tempo=target_tempo,
         ... )
@@ -219,12 +219,12 @@ class NaiveAttackPointOptimizer(AttackPointOptimizer):
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8 g'8 a'8 b'8 c''8")
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> source_tempo = abjad.MetronomeMark((1, 4), 60)
+        >>> source_tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> q_events = nauert.QEventSequence.from_tempo_scaled_leaves(
         ...     staff[:],
         ...     tempo=source_tempo,
         ... )
-        >>> target_tempo = abjad.MetronomeMark((1, 4), 54)
+        >>> target_tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 54)
         >>> q_schema = nauert.MeasurewiseQSchema(
         ...     tempo=target_tempo,
         ... )
@@ -339,12 +339,12 @@ class NullAttackPointOptimizer(AttackPointOptimizer):
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8 g'8 a'8 b'8 c''8")
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> source_tempo = abjad.MetronomeMark((1, 4), 60)
+        >>> source_tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> q_events = nauert.QEventSequence.from_tempo_scaled_leaves(
         ...     staff[:],
         ...     tempo=source_tempo,
         ... )
-        >>> target_tempo = abjad.MetronomeMark((1, 4), 54)
+        >>> target_tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 54)
         >>> q_schema = nauert.MeasurewiseQSchema(
         ...     tempo=target_tempo,
         ... )

--- a/abjadext/nauert/gracehandlers.py
+++ b/abjadext/nauert/gracehandlers.py
@@ -387,6 +387,7 @@ class ConcatenatingGraceHandler(GraceHandler):
             ...     attack_point_optimizer=attack_point_optimizer,
             ... )
             >>> staff = abjad.Staff([result])
+            >>> score = abjad.Score([staff], name="Score")
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::

--- a/abjadext/nauert/qeventsequence.py
+++ b/abjadext/nauert/qeventsequence.py
@@ -370,7 +370,7 @@ class QEventSequence:
 
         ..  container:: example
 
-            >>> tempo = abjad.MetronomeMark((1, 4), 174)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 174)
             >>> durations = [(1, 4), (-3, 16), (1, 16), (-1, 2)]
             >>> sequence = nauert.QEventSequence.from_tempo_scaled_durations(
             ...     durations, tempo=tempo)
@@ -413,7 +413,7 @@ class QEventSequence:
         Changes ``leaves``, optionally with ``tempo`` into a ``QEventSequence``:
 
         >>> staff = abjad.Staff("c'4 <d' fs'>8. r16 gqs'2")
-        >>> tempo = abjad.MetronomeMark((1, 4), 72)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 72)
         >>> sequence = nauert.QEventSequence.from_tempo_scaled_leaves(staff[:], tempo)
         >>> for q_event in sequence:
         ...     q_event

--- a/abjadext/nauert/qschemaitems.py
+++ b/abjadext/nauert/qschemaitems.py
@@ -165,9 +165,12 @@ class MeasurewiseQSchemaItem(QSchemaItem):
     ):
         QSchemaItem.__init__(self, search_tree=search_tree, tempo=tempo)
         self._time_signature: abjad.TimeSignature | None
-        if time_signature is not None:
+        if isinstance(time_signature, abjad.TimeSignature):
+            self._time_signature = abjad.TimeSignature(time_signature.pair)
+        elif isinstance(time_signature, tuple):
             self._time_signature = abjad.TimeSignature(time_signature)
         else:
+            assert time_signature is None
             self._time_signature = None
         if use_full_measure is not None:
             use_full_measure = bool(use_full_measure)

--- a/abjadext/nauert/qschemas.py
+++ b/abjadext/nauert/qschemas.py
@@ -196,7 +196,7 @@ class BeatwiseQSchema(QSchema):
 
         >>> beatspan = abjad.Duration(5, 16)
         >>> search_tree = nauert.UnweightedSearchTree({7: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 54)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 54)
         >>> q_schema = nauert.BeatwiseQSchema(
         ...     beatspan=beatspan,
         ...     search_tree=search_tree,
@@ -310,7 +310,7 @@ class BeatwiseQSchema(QSchema):
         search_tree = keywords.get("search_tree", UnweightedSearchTree())
         assert isinstance(search_tree, SearchTree)
         self._search_tree = search_tree
-        tempo = keywords.get("tempo", ((1, 4), 60))
+        tempo = keywords.get("tempo", (abjad.Duration(1, 4), 60))
         if isinstance(tempo, tuple):
             tempo = abjad.MetronomeMark(*tempo)
         self._tempo = tempo
@@ -382,7 +382,7 @@ class MeasurewiseQSchema(QSchema):
 
         >>> search_tree = nauert.UnweightedSearchTree({7: None})
         >>> time_signature = abjad.TimeSignature((3, 4))
-        >>> tempo = abjad.MetronomeMark((1, 4), 54)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 54)
         >>> use_full_measure = True
         >>> q_schema = nauert.MeasurewiseQSchema(
         ...     search_tree=search_tree,
@@ -532,13 +532,17 @@ class MeasurewiseQSchema(QSchema):
         search_tree = keywords.get("search_tree", UnweightedSearchTree())
         assert isinstance(search_tree, SearchTree)
         self._search_tree = search_tree
-        tempo = keywords.get("tempo", ((1, 4), 60))
+        tempo = keywords.get("tempo", (abjad.Duration(1, 4), 60))
         if isinstance(tempo, tuple):
             tempo = abjad.MetronomeMark(*tempo)
         self._tempo = tempo
-        self._time_signature = abjad.TimeSignature(
-            keywords.get("time_signature", (4, 4))
-        )
+        time_signature = keywords.get("time_signature", (4, 4))
+        if isinstance(time_signature, abjad.TimeSignature):
+            self._time_signature = abjad.TimeSignature(time_signature.pair)
+        elif isinstance(time_signature, tuple):
+            self._time_signature = abjad.TimeSignature(time_signature)
+        else:
+            raise TypeError(time_signature)
         self._use_full_measure = bool(keywords.get("use_full_measure"))
         QSchema.__init__(self, *arguments, **keywords)
 

--- a/abjadext/nauert/qtargetitems.py
+++ b/abjadext/nauert/qtargetitems.py
@@ -35,7 +35,7 @@ class QTargetBeat(QTargetItem):
         >>> beatspan = (1, 8)
         >>> offset_in_ms = 1500
         >>> search_tree = nauert.UnweightedSearchTree({3: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 56)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 56)
 
         >>> q_target_beat = nauert.QTargetBeat(
         ...     beatspan=beatspan,
@@ -87,7 +87,7 @@ class QTargetBeat(QTargetItem):
             reference_duration = abjad.Duration(tempo[0])
             units_per_minute = tempo[1]
             tempo = abjad.MetronomeMark(reference_duration, units_per_minute)
-        tempo = tempo or abjad.MetronomeMark((1, 4), 60)
+        tempo = tempo or abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         assert not tempo.is_imprecise
 
         q_events: list[QEvent] = []
@@ -138,7 +138,7 @@ class QTargetBeat(QTargetItem):
         >>> beatspan = (1, 8)
         >>> offset_in_ms = 1500
         >>> search_tree = nauert.UnweightedSearchTree({3: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 56)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 56)
 
         >>> q_target_beat = nauert.QTargetBeat(
         ...     beatspan=beatspan,
@@ -161,7 +161,7 @@ class QTargetBeat(QTargetItem):
         >>> beatspan = (1, 8)
         >>> offset_in_ms = 1500
         >>> search_tree = nauert.UnweightedSearchTree({3: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 56)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 56)
 
         >>> q_target_beat = nauert.QTargetBeat(
         ...     beatspan=beatspan,
@@ -184,7 +184,7 @@ class QTargetBeat(QTargetItem):
         >>> beatspan = (1, 8)
         >>> offset_in_ms = 1500
         >>> search_tree = nauert.UnweightedSearchTree({3: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 56)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 56)
 
         >>> q_target_beat = nauert.QTargetBeat(
         ...     beatspan=beatspan,
@@ -234,7 +234,7 @@ class QTargetBeat(QTargetItem):
         >>> beatspan = (1, 8)
         >>> offset_in_ms = 1500
         >>> search_tree = nauert.UnweightedSearchTree({3: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 56)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 56)
 
         >>> q_target_beat = nauert.QTargetBeat(
         ...     beatspan=beatspan,
@@ -258,7 +258,7 @@ class QTargetBeat(QTargetItem):
         >>> beatspan = (1, 8)
         >>> offset_in_ms = 1500
         >>> search_tree = nauert.UnweightedSearchTree({3: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 56)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 56)
 
         >>> q_target_beat = nauert.QTargetBeat(
         ...     beatspan=beatspan,
@@ -283,7 +283,7 @@ class QTargetMeasure(QTargetItem):
     ..  container:: example
 
         >>> search_tree = nauert.UnweightedSearchTree({2: None})
-        >>> tempo = abjad.MetronomeMark((1, 4), 60)
+        >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> time_signature = abjad.TimeSignature((4, 4))
 
         >>> q_target_measure = nauert.QTargetMeasure(
@@ -352,7 +352,8 @@ class QTargetMeasure(QTargetItem):
     ):
         offset_in_ms = offset_in_ms or 0
         offset_in_ms = abjad.Offset(offset_in_ms)
-
+        if time_signature is not None:
+            assert isinstance(time_signature, abjad.TimeSignature), repr(time_signature)
         if search_tree is None:
             search_tree = UnweightedSearchTree()
         assert isinstance(search_tree, SearchTree)
@@ -361,10 +362,13 @@ class QTargetMeasure(QTargetItem):
             reference_duration = abjad.Duration(tempo[0])
             units_per_minute = tempo[1]
             tempo = abjad.MetronomeMark(reference_duration, units_per_minute)
-        tempo = tempo or abjad.MetronomeMark((1, 4), 60)
+        tempo = tempo or abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         assert not tempo.is_imprecise
-        time_signature = time_signature or (4, 4)
-        _time_signature = abjad.TimeSignature(time_signature)
+        if time_signature is None:
+            pair = (4, 4)
+        else:
+            pair = time_signature.pair
+        _time_signature = abjad.TimeSignature(pair)
         use_full_measure = bool(use_full_measure)
         beats = []
         if use_full_measure:
@@ -415,7 +419,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(
@@ -444,7 +448,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(
@@ -468,7 +472,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(
@@ -492,7 +496,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(
@@ -516,7 +520,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(
@@ -540,7 +544,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(
@@ -564,7 +568,7 @@ class QTargetMeasure(QTargetItem):
         ..  container:: example
 
             >>> search_tree = nauert.UnweightedSearchTree({2: None})
-            >>> tempo = abjad.MetronomeMark((1, 4), 60)
+            >>> tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
             >>> time_signature = abjad.TimeSignature((4, 4))
 
             >>> q_target_measure = nauert.QTargetMeasure(

--- a/tests/test_BeatwiseQSchemaItem___new__.py
+++ b/tests/test_BeatwiseQSchemaItem___new__.py
@@ -15,7 +15,7 @@ def test_BeatwiseQSchemaItem___new___02():
     item = abjadext.nauert.BeatwiseQSchemaItem(tempo=((1, 4), 60))
     assert item.beatspan is None
     assert item.search_tree is None
-    assert item.tempo == abjad.MetronomeMark((1, 4), 60)
+    assert item.tempo == abjad.MetronomeMark(abjad.Duration(1, 4), 60)
 
 
 def test_BeatwiseQSchemaItem___new___03():
@@ -29,7 +29,7 @@ def test_BeatwiseQSchemaItem___new___04():
     item = abjadext.nauert.BeatwiseQSchemaItem(beatspan=(1, 8), tempo=((1, 4), 57))
     assert item.beatspan == abjad.Duration(1, 8)
     assert item.search_tree is None
-    assert item.tempo == abjad.MetronomeMark((1, 4), 57)
+    assert item.tempo == abjad.MetronomeMark(abjad.Duration(1, 4), 57)
 
 
 def test_BeatwiseQSchemaItem___new___05():

--- a/tests/test_BeatwiseQSchema___getitem__.py
+++ b/tests/test_BeatwiseQSchema___getitem__.py
@@ -12,7 +12,7 @@ def test_BeatwiseQSchema___getitem___01():
         == {
             "beatspan": abjad.Duration(1, 4),
             "search_tree": abjadext.nauert.UnweightedSearchTree(),
-            "tempo": abjad.MetronomeMark((1, 4), 60),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 60),
         }
     )
 
@@ -31,7 +31,7 @@ def test_BeatwiseQSchema___getitem___02():
         {2: item_a, 4: item_b, 7: item_c},
         beatspan=abjad.Duration(1, 32),
         search_tree=abjadext.nauert.UnweightedSearchTree({3: None}),
-        tempo=abjad.MetronomeMark((1, 16), 36),
+        tempo=abjad.MetronomeMark(abjad.Duration(1, 16), 36),
     )
 
     assert (
@@ -40,7 +40,7 @@ def test_BeatwiseQSchema___getitem___02():
         == {
             "beatspan": abjad.Duration(1, 32),
             "search_tree": abjadext.nauert.UnweightedSearchTree({3: None}),
-            "tempo": abjad.MetronomeMark((1, 16), 36),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 16), 36),
         }
     )
 
@@ -50,7 +50,7 @@ def test_BeatwiseQSchema___getitem___02():
         == {
             "beatspan": abjad.Duration(1, 32),
             "search_tree": abjadext.nauert.UnweightedSearchTree({2: None}),
-            "tempo": abjad.MetronomeMark((1, 16), 36),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 16), 36),
         }
     )
 
@@ -61,7 +61,7 @@ def test_BeatwiseQSchema___getitem___02():
         == {
             "beatspan": abjad.Duration(1, 32),
             "search_tree": abjadext.nauert.UnweightedSearchTree({2: None}),
-            "tempo": abjad.MetronomeMark((1, 4), 76),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 76),
         }
     )
 
@@ -72,6 +72,6 @@ def test_BeatwiseQSchema___getitem___02():
         == {
             "beatspan": abjad.Duration(1, 8),
             "search_tree": abjadext.nauert.UnweightedSearchTree({5: None}),
-            "tempo": abjad.MetronomeMark((1, 4), 76),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 76),
         }
     )

--- a/tests/test_BeatwiseQSchema___init__.py
+++ b/tests/test_BeatwiseQSchema___init__.py
@@ -13,13 +13,13 @@ def test_BeatwiseQSchema___init___01():
         {2: item_a, 4: item_b, 7: item_c},
         beatspan=abjad.Duration(1, 32),
         search_tree=abjadext.nauert.UnweightedSearchTree({3: None}),
-        tempo=abjad.MetronomeMark((1, 16), 32),
+        tempo=abjad.MetronomeMark(abjad.Duration(1, 16), 32),
     )
 
     assert len(schema.items) == 3
     assert schema.beatspan == abjad.Duration(1, 32)
     assert schema.search_tree == abjadext.nauert.UnweightedSearchTree({3: None})
-    assert schema.tempo == abjad.MetronomeMark((1, 16), 32)
+    assert schema.tempo == abjad.MetronomeMark(abjad.Duration(1, 16), 32)
 
 
 def test_BeatwiseQSchema___init___02():
@@ -28,4 +28,4 @@ def test_BeatwiseQSchema___init___02():
     assert len(schema.items) == 0
     assert schema.beatspan == abjad.Duration(1, 4)
     assert schema.search_tree == abjadext.nauert.UnweightedSearchTree()
-    assert schema.tempo == abjad.MetronomeMark((1, 4), 60)
+    assert schema.tempo == abjad.MetronomeMark(abjad.Duration(1, 4), 60)

--- a/tests/test_MeasurewiseQSchemaItem___new__.py
+++ b/tests/test_MeasurewiseQSchemaItem___new__.py
@@ -16,7 +16,7 @@ def test_MeasurewiseQSchemaItem___new___02():
     item = abjadext.nauert.MeasurewiseQSchemaItem(tempo=((1, 4), 60))
     assert item.beatspan is None
     assert item.search_tree is None
-    assert item.tempo == abjad.MetronomeMark((1, 4), 60)
+    assert item.tempo == abjad.MetronomeMark(abjad.Duration(1, 4), 60)
     assert item.time_signature is None
 
 
@@ -34,7 +34,7 @@ def test_MeasurewiseQSchemaItem___new___04():
     )
     assert item.beatspan == abjad.Duration(1, 8)
     assert item.search_tree is None
-    assert item.tempo == abjad.MetronomeMark((1, 4), 57)
+    assert item.tempo == abjad.MetronomeMark(abjad.Duration(1, 4), 57)
     assert item.time_signature == abjad.TimeSignature((6, 8))
 
 

--- a/tests/test_MeasurewiseQSchema___getitem__.py
+++ b/tests/test_MeasurewiseQSchema___getitem__.py
@@ -11,7 +11,7 @@ def test_MeasurewiseQSchema___getitem___01():
         == schema[2]
         == {
             "search_tree": abjadext.nauert.UnweightedSearchTree(),
-            "tempo": abjad.MetronomeMark((1, 4), 60),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 60),
             "time_signature": abjad.TimeSignature((4, 4)),
             "use_full_measure": False,
         }
@@ -32,7 +32,7 @@ def test_MeasurewiseQSchema___getitem___02():
     schema = abjadext.nauert.MeasurewiseQSchema(
         {2: item_a, 4: item_b, 7: item_c, 8: item_d},
         search_tree=abjadext.nauert.UnweightedSearchTree({3: None}),
-        tempo=((1, 8), 58),
+        tempo=(abjad.Duration(1, 8), 58),
         time_signature=(5, 8),
         use_full_measure=False,
     )
@@ -42,7 +42,7 @@ def test_MeasurewiseQSchema___getitem___02():
         == schema[1]
         == {
             "search_tree": abjadext.nauert.UnweightedSearchTree({3: None}),
-            "tempo": abjad.MetronomeMark((1, 8), 58),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 8), 58),
             "time_signature": abjad.TimeSignature((5, 8)),
             "use_full_measure": False,
         }
@@ -53,7 +53,7 @@ def test_MeasurewiseQSchema___getitem___02():
         == schema[3]
         == {
             "search_tree": abjadext.nauert.UnweightedSearchTree({2: None}),
-            "tempo": abjad.MetronomeMark((1, 8), 58),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 8), 58),
             "time_signature": abjad.TimeSignature((5, 8)),
             "use_full_measure": False,
         }
@@ -65,7 +65,7 @@ def test_MeasurewiseQSchema___getitem___02():
         == schema[6]
         == {
             "search_tree": abjadext.nauert.UnweightedSearchTree({2: None}),
-            "tempo": abjad.MetronomeMark((1, 4), 76),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 76),
             "time_signature": abjad.TimeSignature((5, 8)),
             "use_full_measure": False,
         }
@@ -73,7 +73,7 @@ def test_MeasurewiseQSchema___getitem___02():
 
     assert schema[7] == {
         "search_tree": abjadext.nauert.UnweightedSearchTree({2: None}),
-        "tempo": abjad.MetronomeMark((1, 4), 76),
+        "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 76),
         "time_signature": abjad.TimeSignature((3, 4)),
         "use_full_measure": False,
     }
@@ -84,7 +84,7 @@ def test_MeasurewiseQSchema___getitem___02():
         == schema[1000]
         == {
             "search_tree": abjadext.nauert.UnweightedSearchTree({5: None}),
-            "tempo": abjad.MetronomeMark((1, 4), 76),
+            "tempo": abjad.MetronomeMark(abjad.Duration(1, 4), 76),
             "time_signature": abjad.TimeSignature((3, 4)),
             "use_full_measure": True,
         }

--- a/tests/test_MeasurewiseQSchema___init__.py
+++ b/tests/test_MeasurewiseQSchema___init__.py
@@ -13,14 +13,14 @@ def test_MeasurewiseQSchema___init___01():
     schema = abjadext.nauert.MeasurewiseQSchema(
         {2: item_a, 4: item_b, 7: item_c, 8: item_d},
         search_tree=abjadext.nauert.UnweightedSearchTree({3: None}),
-        tempo=((1, 8), 58),
+        tempo=(abjad.Duration(1, 8), 58),
         time_signature=(5, 8),
         use_full_measure=False,
     )
 
     assert len(schema.items) == 4
     assert schema.search_tree == abjadext.nauert.UnweightedSearchTree({3: None})
-    assert schema.tempo == abjad.MetronomeMark((1, 8), 58)
+    assert schema.tempo == abjad.MetronomeMark(abjad.Duration(1, 8), 58)
     assert schema.time_signature == abjad.TimeSignature((5, 8))
     assert schema.use_full_measure is False
 
@@ -30,6 +30,6 @@ def test_MeasurewiseQSchema___init___02():
 
     assert len(schema.items) == 0
     assert schema.search_tree == abjadext.nauert.UnweightedSearchTree()
-    assert schema.tempo == abjad.MetronomeMark((1, 4), 60)
+    assert schema.tempo == abjad.MetronomeMark(abjad.Duration(1, 4), 60)
     assert schema.time_signature == abjad.TimeSignature((4, 4))
     assert schema.use_full_measure is False

--- a/tests/test_QEventSequence_from_tempo_scaled_durations.py
+++ b/tests/test_QEventSequence_from_tempo_scaled_durations.py
@@ -7,7 +7,7 @@ def test_QEventSequence_from_tempo_scaled_durations_01():
     Test basic functionality.
     """
     durations = [abjad.Duration(x) for x in [(1, 4), (1, 3), (1, 7), (2, 5), (3, 4)]]
-    tempo = abjad.MetronomeMark((1, 4), 55)
+    tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 55)
     q_events = abjadext.nauert.QEventSequence.from_tempo_scaled_durations(
         durations, tempo
     )
@@ -41,7 +41,7 @@ def test_QEventSequence_from_tempo_scaled_durations_02():
         abjad.Duration(x)
         for x in [(1, 4), (-1, 4), (1, 4), (1, 4), (-1, 4), (-1, 4), (1, 4)]
     ]
-    tempo = abjad.MetronomeMark((1, 4), 77)
+    tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 77)
     q_events = abjadext.nauert.QEventSequence.from_tempo_scaled_durations(
         durations, tempo
     )

--- a/tests/test_QEventSequence_from_tempo_scaled_leaves.py
+++ b/tests/test_QEventSequence_from_tempo_scaled_leaves.py
@@ -21,7 +21,7 @@ def test_QEventSequence_from_tempo_scaled_leaves_01():
     abjad.tie(staff[3:5])
     abjad.tie(staff[5:7])
 
-    tempo = abjad.MetronomeMark((1, 4), 55)
+    tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 55)
 
     leaves = abjad.select.leaves(staff)
     q_events = abjadext.nauert.QEventSequence.from_tempo_scaled_leaves(leaves, tempo)
@@ -77,9 +77,9 @@ def test_QEventSequence_from_tempo_scaled_leaves_02():
     abjad.tie(staff[3:5])
     abjad.tie(staff[5:7])
 
-    tempo = abjad.MetronomeMark((1, 4), 58)
+    tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 58)
     abjad.attach(tempo, staff[0], context="Staff")
-    tempo = abjad.MetronomeMark((1, 4), 77)
+    tempo = abjad.MetronomeMark(abjad.Duration(1, 4), 77)
     abjad.attach(tempo, staff[9], context="Staff")
 
     leaves = abjad.select.leaves(staff)

--- a/tests/test_Quantizer___call__.py
+++ b/tests/test_Quantizer___call__.py
@@ -489,6 +489,7 @@ def test_Quantize_11():
         attack_point_optimizer=attack_point_optimizer,
     )
     staff = abjad.Staff([result])
+    abjad.Score([staff], name="Score")
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
@@ -530,6 +531,7 @@ def test_Quantize_12():
     )
     result = nauert.quantize(q_event_sequence, q_schema=q_schema, attach_tempos=True)
     staff = abjad.Staff([result])
+    abjad.Score([staff], name="Score")
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
@@ -588,6 +590,7 @@ def test_Quantize_13():
     )
     result = nauert.quantize(q_event_sequence, q_schema=q_schema, attach_tempos=True)
     staff = abjad.Staff([result])
+    abjad.Score([staff], name="Score")
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
@@ -657,6 +660,7 @@ def test_Quantize_14():
         attach_tempos=True,
     )
     staff = abjad.Staff([result])
+    abjad.Score([staff], name="Score")
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
@@ -710,6 +714,7 @@ def test_Quantize_15():
     )
 
     staff = abjad.Staff([result])
+    abjad.Score([staff], name="Score")
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
@@ -754,7 +759,7 @@ def test_Quantize_16():
     attack_point_optimizer = nauert.MeasurewiseAttackPointOptimizer()
     q_schema = nauert.MeasurewiseQSchema(
         search_tree=search_tree,
-        tempo=abjad.MetronomeMark((1, 4), 72),
+        tempo=abjad.MetronomeMark(abjad.Duration(1, 4), 72),
         time_signature=(7, 8),
         use_full_measure=True,
     )
@@ -765,6 +770,7 @@ def test_Quantize_16():
         attack_point_optimizer=attack_point_optimizer,
     )
     staff = abjad.Staff([result])
+    abjad.Score([staff], name="Score")
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""


### PR DESCRIPTION
Time signatures and metronome marks are frozen dataclasses in Abjad 3.17.

Cleaned up time signature initialization for Abjad 3.17.

Cleaned up metronome mark initialization for Abajd 3.17.

Added explicit score contexts to tests.