### PR TITLE
Removes target-version in black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: docs build
 
 black-check:
-	black --check --diff --target-version=py38 .
+	black --check --diff .
 
 black-reformat:
-	black --target-version=py38 .
+	black .
 
 build:
 	python setup.py sdist


### PR DESCRIPTION
The target version of black was Python 3.8. Now that Abjad is using 3.10 and 3.11, it should probably be updated.

[Abjad's Makefile](https://github.com/Abjad/abjad/blob/e77adbcefa854f4d02fa8f3169a0bc6f83c77583/Makefile#L3-L7) does not specify target version(s), but according to [Black's documentation](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version), it seems like one
> should include all versions that your code supports

I'm just going to not specify any target version in this PR. It probably makes it a bit easier when upgrading the python version.

cc @trevorbaca 