### PR TITLE
teaches DiscardingGraceHandler to record discarded Q Events

### DIFF
--- a/abjadext/nauert/gracehandlers.py
+++ b/abjadext/nauert/gracehandlers.py
@@ -494,11 +494,19 @@ class DiscardingGraceHandler(GraceHandler):
                 }
             }
 
+        >>> grace_handler.discarded_q_events
+        [[(PitchedQEvent(offset=Offset((1000, 1)), pitches=(NamedPitch("c'"),), index=None, attachments=()),)]]
+
     """
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ()
+    __slots__ = ("_discarded_q_events",)
+
+    ### INITIALIZER ###
+
+    def __init__(self):
+        self._discarded_q_events: [QEvent] = []
 
     ### SPECIAL METHODS ###
 
@@ -508,7 +516,16 @@ class DiscardingGraceHandler(GraceHandler):
         """
         Calls discarding grace handler.
         """
+        if q_events[:-1]:
+            self._discarded_q_events.append([q_events[:-1]])
         q_event = q_events[-1]
         if isinstance(q_event, PitchedQEvent):
             return tuple(q_event.pitches), tuple(q_event.attachments), None
         return (), (), None
+
+    @property
+    def discarded_q_events(self):
+        """
+        Returns the discarded QEvents.
+        """
+        return self._discarded_q_events

--- a/abjadext/nauert/gracehandlers.py
+++ b/abjadext/nauert/gracehandlers.py
@@ -468,8 +468,8 @@ class DiscardingGraceHandler(GraceHandler):
 
     ..  container:: example
 
-        >>> durations = [1000, 1, 999]
-        >>> pitches = [0, 0, 1]
+        >>> durations = [1000, 1, 1, 998]
+        >>> pitches = [0, 1, 2, 3]
         >>> q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
         ...     tuple(zip(durations, pitches))
         ... )
@@ -488,14 +488,14 @@ class DiscardingGraceHandler(GraceHandler):
                     \tempo 4=60
                     %%% \time 4/4 %%%
                     c'4
-                    cs'4
+                    ef'4
                     r4
                     r4
                 }
             }
 
         >>> grace_handler.discarded_q_events
-        [[(PitchedQEvent(offset=Offset((1000, 1)), pitches=(NamedPitch("c'"),), index=None, attachments=()),)]]
+        [(PitchedQEvent(offset=Offset((1000, 1)), pitches=(NamedPitch("cs'"),), index=None, attachments=()), PitchedQEvent(offset=Offset((1001, 1)), pitches=(NamedPitch("d'"),), index=None, attachments=()))]
 
     """
 
@@ -505,8 +505,8 @@ class DiscardingGraceHandler(GraceHandler):
 
     ### INITIALIZER ###
 
-    def __init__(self):
-        self._discarded_q_events: [QEvent] = []
+    def __init__(self) -> None:
+        self._discarded_q_events: list[typing.Sequence[QEvent]] = []
 
     ### SPECIAL METHODS ###
 
@@ -517,14 +517,14 @@ class DiscardingGraceHandler(GraceHandler):
         Calls discarding grace handler.
         """
         if q_events[:-1]:
-            self._discarded_q_events.append([q_events[:-1]])
+            self._discarded_q_events.append(q_events[:-1])
         q_event = q_events[-1]
         if isinstance(q_event, PitchedQEvent):
             return tuple(q_event.pitches), tuple(q_event.attachments), None
         return (), (), None
 
     @property
-    def discarded_q_events(self):
+    def discarded_q_events(self) -> list[typing.Sequence[QEvent]]:
         """
         Returns the discarded QEvents.
         """

--- a/tests/test_DiscardingGraceHandler___call__.py
+++ b/tests/test_DiscardingGraceHandler___call__.py
@@ -1,0 +1,34 @@
+import abjad
+from abjadext import nauert
+
+
+def test_DiscardingGraceHandler___call___01():
+    grace_handler = nauert.DiscardingGraceHandler()
+    durations = [1000, 1, 1, 998, 1, 999, 1, 999]
+    pitches = [0, 1, 2, 3, 4, 5, 6, None]
+    q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
+        tuple(zip(durations, pitches))
+    )
+    result = nauert.quantize(q_event_sequence, grace_handler=grace_handler)
+    assert abjad.lilypond(result) == abjad.string.normalize(
+        r"""
+        \new Voice
+        {
+            {
+                \tempo 4=60
+                %%% \time 4/4 %%%
+                c'4
+                ef'4
+                f'4
+                r4
+            }
+        }
+        """
+    ), print(abjad.lilypond(result))
+    assert len(grace_handler.discarded_q_events) == 3
+    assert grace_handler.discarded_q_events[0] == (
+        nauert.PitchedQEvent(1000, [1]),
+        nauert.PitchedQEvent(1001, [2]),
+    )
+    assert grace_handler.discarded_q_events[1] == (nauert.PitchedQEvent(2000, [4]),)
+    assert grace_handler.discarded_q_events[2] == (nauert.PitchedQEvent(3000, [6]),)


### PR DESCRIPTION
This PR adds a new property to `DiscardingGraceHandler` to track the discarded q events:
```python
>>> durations = [1000, 1, 1, 998]
>>> pitches = [0, 1, 2, 3]
>>> q_event_sequence = nauert.QEventSequence.from_millisecond_pitch_pairs(
...     tuple(zip(durations, pitches))
... )
>>> grace_handler = nauert.DiscardingGraceHandler()
>>> result = nauert.quantize(
...     q_event_sequence, grace_handler=grace_handler
... )
>>> grace_handler.discarded_q_events
[(PitchedQEvent(offset=Offset((1000, 1)), pitches=(NamedPitch("cs'"),), index=None, attachments=()), PitchedQEvent(offset=Offset((1001, 1)), pitches=(NamedPitch("d'"),), index=None, attachments=()))]
```