### PR TITLE
Clean up rhythmtrees.py

### DIFF
--- a/abjadext/nauert/attackpointoptimizers.py
+++ b/abjadext/nauert/attackpointoptimizers.py
@@ -214,7 +214,10 @@ class MeasurewiseAttackPointOptimizer(AttackPointOptimizer):
         )
         assert time_signature is not None, repr(time_signature)
         all_annotations = self._get_attachment_annotations_of_logical_ties(argument[:])
-        abjad.Meter.rewrite_meter(argument[:], time_signature, boundary_depth=1)
+        # abjad.Meter.rewrite_meter(argument[:], time_signature, boundary_depth=1)
+        # abjad.Meter.rewrite_meter(argument[:], time_signature, boundary_depth=1)
+        meter = abjad.Meter(time_signature.pair)
+        abjad.Meter.rewrite_meter(argument[:], meter, boundary_depth=1)
         assert len(all_annotations) == len(
             list(abjad.iterate.logical_ties(argument[:], pitched=True))
         )

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -114,7 +114,6 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNod
         """
         RTM format of q-grid leaf.
         """
-        # return str(self.preprolated_pair)
         numerator, denominator = self.preprolated_pair
         assert denominator == 1, repr(denominator)
         return str(numerator)
@@ -133,7 +132,7 @@ class QGridContainer(abjad.rhythmtrees.RhythmTreeContainer):
 
     ..  container:: example
 
-        >>> nauert.QGridContainer()
+        >>> nauert.QGridContainer((1, 1))
         QGridContainer((1, 1))
 
     Used internally by ``QGrid``.

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -9,7 +9,7 @@ import uqbar.graphs
 from .qeventproxy import QEventProxy
 
 
-class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNode):
+class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNode):
     """
     Q-grid leaf.
 
@@ -34,8 +34,7 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         assert isinstance(preprolated_duration, abjad.Duration), repr(
             preprolated_duration
         )
-        # abjad.rhythmtrees.RhythmTreeMixin.__init__(self, preprolated_duration)
-        abjad.rhythmtrees.RhythmTreeMixin.__init__(self, preprolated_duration.pair)
+        abjad.rhythmtrees.RhythmTreeNode.__init__(self, preprolated_duration.pair)
         if q_event_proxies is None:
             self._q_event_proxies = []
         else:
@@ -52,7 +51,6 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         Calls q-grid leaf.
         """
         pulse_duration = abjad.Duration(pulse_duration)
-        # total_duration = pulse_duration * abjad.Duration(self.preprolated_duration)
         total_duration = pulse_duration * abjad.Duration(self.preprolated_pair)
         return abjad.makers.make_notes(0, total_duration)
 

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -16,7 +16,7 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNod
     ..  container:: example
 
         >>> nauert.QGridLeaf()
-        QGridLeaf(preprolated_pair=(1, 1), q_event_proxies=[], is_divisible=True)
+        QGridLeaf((1, 1), q_event_proxies=[], is_divisible=True)
 
     Used internally by ``QGrid``.
     """
@@ -51,7 +51,7 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNod
         Calls q-grid leaf.
         """
         pulse_duration = abjad.Duration(pulse_duration)
-        total_duration = pulse_duration * abjad.Duration(self.preprolated_pair)
+        total_duration = pulse_duration * abjad.Duration(self.pair)
         return abjad.makers.make_notes(0, total_duration)
 
     def __graph__(self, **keywords: None) -> uqbar.graphs.Graph:
@@ -61,7 +61,7 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNod
         Returns Graphviz graph.
         """
         graph = uqbar.graphs.Graph(name="G")
-        label = str(self.preprolated_pair)
+        label = str(self.pair)
         node = uqbar.graphs.Node(attributes={"label": label, "shape": "box"})
         graph.append(node)
         return graph
@@ -70,14 +70,13 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNod
         """
         Gets repr.
         """
-        return f"{type(self).__name__}(preprolated_pair={self.preprolated_pair!r}, q_event_proxies={self.q_event_proxies!r}, is_divisible={self.is_divisible!r})"
+        return f"{type(self).__name__}({self.pair!r}, q_event_proxies={self.q_event_proxies!r}, is_divisible={self.is_divisible!r})"
 
     ### PRIVATE PROPERTIES ###
 
     @property
     def _pretty_rtm_format_pieces(self) -> list[str]:
-        # return [str(self.preprolated_duration)]
-        numerator, denominator = self.preprolated_pair
+        numerator, denominator = self.pair
         assert denominator == 1, repr(denominator)
         return [str(numerator)]
 
@@ -114,7 +113,7 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeNode, uqbar.containers.UniqueTreeNod
         """
         RTM format of q-grid leaf.
         """
-        numerator, denominator = self.preprolated_pair
+        numerator, denominator = self.pair
         assert denominator == 1, repr(denominator)
         return str(numerator)
 
@@ -170,7 +169,7 @@ class QGrid:
     ..  container:: example
 
         >>> q_grid
-        QGrid(root_node=QGridLeaf(preprolated_pair=(1, 1), q_event_proxies=[], is_divisible=True), next_downbeat=QGridLeaf(preprolated_pair=(1, 1), q_event_proxies=[], is_divisible=True))
+        QGrid(root_node=QGridLeaf((1, 1), q_event_proxies=[], is_divisible=True), next_downbeat=QGridLeaf((1, 1), q_event_proxies=[], is_divisible=True))
 
     ..  container:: example
 
@@ -458,9 +457,7 @@ class QGrid:
                 if len(leaves) > 1 and all(
                     [_leaf.q_event_proxies == [] for _leaf in leaves[1:]]
                 ):
-                    # parent_preprolated_duration = parent.preprolated_duration
-                    # assert isinstance(parent_preprolated_duration, abjad.Duration)
-                    parent_preprolated_duration = parent.preprolated_pair
+                    parent_preprolated_duration = parent.pair
                     new_leaf = QGridLeaf(
                         preprolated_duration=parent_preprolated_duration,
                         q_event_proxies=leaves[0].q_event_proxies,
@@ -499,8 +496,7 @@ class QGrid:
                 child = QGridLeaf(preprolated_duration=subdivision)
                 children.append(child)
         container = QGridContainer(
-            # preprolated_duration=leaf.preprolated_duration,
-            preprolated_pair=leaf.preprolated_pair,
+            leaf.pair,
             children=[
                 QGridLeaf(preprolated_duration=abjad.Duration(subdivision))
                 for subdivision in subdivisions

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -236,13 +236,13 @@ class QGrid:
         Calls q-grid.
         """
         if isinstance(beatspan, tuple):
-            pair = beatspan
+            duration = abjad.Duration(beatspan)
         elif isinstance(beatspan, abjad.Duration):
-            pair = beatspan.pair
+            duration = beatspan
         else:
             assert isinstance(beatspan, int), repr(beatspan)
-            pair = (beatspan, 1)
-        result = self.root_node(pair)
+            duration = abjad.Duration(beatspan, 1)
+        result = self.root_node(duration)
         result_logical_ties = [
             logical_tie for logical_tie in abjad.iterate.logical_ties(result)
         ]

--- a/abjadext/nauert/qgrid.py
+++ b/abjadext/nauert/qgrid.py
@@ -16,7 +16,7 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
     ..  container:: example
 
         >>> nauert.QGridLeaf()
-        QGridLeaf(preprolated_duration=Duration(1, 1), q_event_proxies=[], is_divisible=True)
+        QGridLeaf(preprolated_pair=(1, 1), q_event_proxies=[], is_divisible=True)
 
     Used internally by ``QGrid``.
     """
@@ -34,7 +34,8 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         assert isinstance(preprolated_duration, abjad.Duration), repr(
             preprolated_duration
         )
-        abjad.rhythmtrees.RhythmTreeMixin.__init__(self, preprolated_duration)
+        # abjad.rhythmtrees.RhythmTreeMixin.__init__(self, preprolated_duration)
+        abjad.rhythmtrees.RhythmTreeMixin.__init__(self, preprolated_duration.pair)
         if q_event_proxies is None:
             self._q_event_proxies = []
         else:
@@ -51,7 +52,8 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         Calls q-grid leaf.
         """
         pulse_duration = abjad.Duration(pulse_duration)
-        total_duration = pulse_duration * abjad.Duration(self.preprolated_duration)
+        # total_duration = pulse_duration * abjad.Duration(self.preprolated_duration)
+        total_duration = pulse_duration * abjad.Duration(self.preprolated_pair)
         return abjad.makers.make_notes(0, total_duration)
 
     def __graph__(self, **keywords: None) -> uqbar.graphs.Graph:
@@ -61,9 +63,8 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         Returns Graphviz graph.
         """
         graph = uqbar.graphs.Graph(name="G")
-        node = uqbar.graphs.Node(
-            attributes={"label": str(self.preprolated_duration), "shape": "box"}
-        )
+        label = str(self.preprolated_pair)
+        node = uqbar.graphs.Node(attributes={"label": label, "shape": "box"})
         graph.append(node)
         return graph
 
@@ -71,13 +72,16 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         """
         Gets repr.
         """
-        return f"{type(self).__name__}(preprolated_duration={self.preprolated_duration!r}, q_event_proxies={self.q_event_proxies!r}, is_divisible={self.is_divisible!r})"
+        return f"{type(self).__name__}(preprolated_pair={self.preprolated_pair!r}, q_event_proxies={self.q_event_proxies!r}, is_divisible={self.is_divisible!r})"
 
     ### PRIVATE PROPERTIES ###
 
     @property
     def _pretty_rtm_format_pieces(self) -> list[str]:
-        return [str(self.preprolated_duration)]
+        # return [str(self.preprolated_duration)]
+        numerator, denominator = self.preprolated_pair
+        assert denominator == 1, repr(denominator)
+        return [str(numerator)]
 
     ### PUBLIC PROPERTIES ###
 
@@ -112,7 +116,10 @@ class QGridLeaf(abjad.rhythmtrees.RhythmTreeMixin, uqbar.containers.UniqueTreeNo
         """
         RTM format of q-grid leaf.
         """
-        return str(self.preprolated_duration)
+        # return str(self.preprolated_pair)
+        numerator, denominator = self.preprolated_pair
+        assert denominator == 1, repr(denominator)
+        return str(numerator)
 
     @property
     def succeeding_q_event_proxies(self) -> list[QEventProxy]:
@@ -166,7 +173,7 @@ class QGrid:
     ..  container:: example
 
         >>> q_grid
-        QGrid(root_node=QGridLeaf(preprolated_duration=Duration(1, 1), q_event_proxies=[], is_divisible=True), next_downbeat=QGridLeaf(preprolated_duration=Duration(1, 1), q_event_proxies=[], is_divisible=True))
+        QGrid(root_node=QGridLeaf(preprolated_pair=(1, 1), q_event_proxies=[], is_divisible=True), next_downbeat=QGridLeaf(preprolated_pair=(1, 1), q_event_proxies=[], is_divisible=True))
 
     ..  container:: example
 
@@ -226,12 +233,19 @@ class QGrid:
     ### SPECIAL METHODS ###
 
     def __call__(
-        self, beatspan: abjad.typings.Duration | int
+        self, beatspan: tuple | abjad.typings.Duration | int
     ) -> list[abjad.Note | abjad.Tuplet] | list[abjad.Leaf | abjad.Tuplet]:
         """
         Calls q-grid.
         """
-        result = self.root_node(beatspan)
+        if isinstance(beatspan, tuple):
+            pair = beatspan
+        elif isinstance(beatspan, abjad.Duration):
+            pair = beatspan.pair
+        else:
+            assert isinstance(beatspan, int), repr(beatspan)
+            pair = (beatspan, 1)
+        result = self.root_node(pair)
         result_logical_ties = [
             logical_tie for logical_tie in abjad.iterate.logical_ties(result)
         ]
@@ -405,9 +419,8 @@ class QGrid:
 
     @property
     def rtm_format(self) -> str:
-        r"""The RTM format of the root node of the ``QGrid``.
-
-        Returns string.
+        """
+        The RTM format of the root node of the ``QGrid``.
         """
         return self._root_node.rtm_format
 
@@ -448,8 +461,9 @@ class QGrid:
                 if len(leaves) > 1 and all(
                     [_leaf.q_event_proxies == [] for _leaf in leaves[1:]]
                 ):
-                    parent_preprolated_duration = parent.preprolated_duration
-                    assert isinstance(parent_preprolated_duration, abjad.Duration)
+                    # parent_preprolated_duration = parent.preprolated_duration
+                    # assert isinstance(parent_preprolated_duration, abjad.Duration)
+                    parent_preprolated_duration = parent.preprolated_pair
                     new_leaf = QGridLeaf(
                         preprolated_duration=parent_preprolated_duration,
                         q_event_proxies=leaves[0].q_event_proxies,
@@ -474,9 +488,10 @@ class QGrid:
         leaf: QGridLeaf,
         subdivisions: typing.Sequence[abjad.typings.Duration | int],
     ) -> list[QEventProxy]:
-        r"""Replace the ``QGridLeaf`` ``leaf`` contained in a ``QGrid``
-        by a ``QGridContainer`` containing ``QGridLeaves`` with durations
-        equal to the ratio described in ``subdivisions``
+        r"""
+        Replace the ``QGridLeaf`` ``leaf`` contained in a ``QGrid`` by a
+        ``QGridContainer`` containing ``QGridLeaves`` with durations equal to
+        the ratio described in ``subdivisions``
 
         Returns the ``QEventProxies`` attached to ``leaf``.
         """
@@ -487,7 +502,8 @@ class QGrid:
                 child = QGridLeaf(preprolated_duration=subdivision)
                 children.append(child)
         container = QGridContainer(
-            preprolated_duration=leaf.preprolated_duration,
+            # preprolated_duration=leaf.preprolated_duration,
+            preprolated_pair=leaf.preprolated_pair,
             children=[
                 QGridLeaf(preprolated_duration=abjad.Duration(subdivision))
                 for subdivision in subdivisions

--- a/tests/test_QGridContainer___copy__.py
+++ b/tests/test_QGridContainer___copy__.py
@@ -5,15 +5,15 @@ import abjadext.nauert
 
 def test_QGridContainer___copy___01():
     tree = abjadext.nauert.QGridContainer(
-        preprolated_pair=(1, 1),
+        (1, 1),
         children=[
             abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),
             abjadext.nauert.QGridContainer(
-                preprolated_pair=(2, 1),
+                (2, 1),
                 children=[
                     abjadext.nauert.QGridLeaf(preprolated_duration=(3, 1)),
                     abjadext.nauert.QGridContainer(
-                        preprolated_pair=(4, 1),
+                        (4, 1),
                         children=[
                             abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),
                             abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),

--- a/tests/test_QGridContainer___copy__.py
+++ b/tests/test_QGridContainer___copy__.py
@@ -1,40 +1,30 @@
 import copy
 
-import abjad
 import abjadext.nauert
 
 
 def test_QGridContainer___copy___01():
     tree = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1),
+        preprolated_pair=(1, 1),
         children=[
-            abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1)),
+            abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),
             abjadext.nauert.QGridContainer(
-                preprolated_duration=abjad.Duration(2, 1),
+                preprolated_pair=(2, 1),
                 children=[
-                    abjadext.nauert.QGridLeaf(
-                        preprolated_duration=abjad.Duration(3, 1)
-                    ),
+                    abjadext.nauert.QGridLeaf(preprolated_duration=(3, 1)),
                     abjadext.nauert.QGridContainer(
-                        preprolated_duration=abjad.Duration(4, 1),
+                        preprolated_pair=(4, 1),
                         children=[
-                            abjadext.nauert.QGridLeaf(
-                                preprolated_duration=abjad.Duration(1, 1)
-                            ),
-                            abjadext.nauert.QGridLeaf(
-                                preprolated_duration=abjad.Duration(1, 1)
-                            ),
-                            abjadext.nauert.QGridLeaf(
-                                preprolated_duration=abjad.Duration(1, 1)
-                            ),
+                            abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),
+                            abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),
+                            abjadext.nauert.QGridLeaf(preprolated_duration=(1, 1)),
                         ],
                     ),
                 ],
             ),
-            abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(2, 1)),
+            abjadext.nauert.QGridLeaf(preprolated_duration=(2, 1)),
         ],
     )
-
     copied = copy.deepcopy(tree)
 
     assert format(tree) == format(copied)

--- a/tests/test_QGridContainer___eq__.py
+++ b/tests/test_QGridContainer___eq__.py
@@ -3,12 +3,8 @@ import abjadext.nauert
 
 
 def test_QGridContainer___eq___01():
-    a = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1), children=[]
-    )
-    b = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1), children=[]
-    )
+    a = abjadext.nauert.QGridContainer(preprolated_pair=(1, 1), children=[])
+    b = abjadext.nauert.QGridContainer(preprolated_pair=(1, 1), children=[])
 
     assert format(a) == format(b)
     assert a != b
@@ -16,11 +12,11 @@ def test_QGridContainer___eq___01():
 
 def test_QGridContainer___eq___02():
     a = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1),
+        preprolated_pair=(1, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
     b = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1),
+        preprolated_pair=(1, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
 
@@ -29,22 +25,18 @@ def test_QGridContainer___eq___02():
 
 
 def test_QGridContainer___eq___03():
-    a = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1), children=[]
-    )
-    b = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(2, 1), children=[]
-    )
+    a = abjadext.nauert.QGridContainer(preprolated_pair=(1, 1), children=[])
+    b = abjadext.nauert.QGridContainer(preprolated_pair=(2, 1), children=[])
     c = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(1, 1),
+        preprolated_pair=(1, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
     d = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(2, 1),
+        preprolated_pair=(2, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
     e = abjadext.nauert.QGridContainer(
-        preprolated_duration=abjad.Duration(2, 1),
+        preprolated_pair=(2, 1),
         children=[abjadext.nauert.QGridLeaf(abjad.Duration(2))],
     )
 

--- a/tests/test_QGridContainer___eq__.py
+++ b/tests/test_QGridContainer___eq__.py
@@ -3,8 +3,8 @@ import abjadext.nauert
 
 
 def test_QGridContainer___eq___01():
-    a = abjadext.nauert.QGridContainer(preprolated_pair=(1, 1), children=[])
-    b = abjadext.nauert.QGridContainer(preprolated_pair=(1, 1), children=[])
+    a = abjadext.nauert.QGridContainer((1, 1), children=[])
+    b = abjadext.nauert.QGridContainer((1, 1), children=[])
 
     assert format(a) == format(b)
     assert a != b
@@ -12,11 +12,11 @@ def test_QGridContainer___eq___01():
 
 def test_QGridContainer___eq___02():
     a = abjadext.nauert.QGridContainer(
-        preprolated_pair=(1, 1),
+        (1, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
     b = abjadext.nauert.QGridContainer(
-        preprolated_pair=(1, 1),
+        (1, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
 
@@ -25,18 +25,18 @@ def test_QGridContainer___eq___02():
 
 
 def test_QGridContainer___eq___03():
-    a = abjadext.nauert.QGridContainer(preprolated_pair=(1, 1), children=[])
-    b = abjadext.nauert.QGridContainer(preprolated_pair=(2, 1), children=[])
+    a = abjadext.nauert.QGridContainer((1, 1), children=[])
+    b = abjadext.nauert.QGridContainer((2, 1), children=[])
     c = abjadext.nauert.QGridContainer(
-        preprolated_pair=(1, 1),
+        (1, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
     d = abjadext.nauert.QGridContainer(
-        preprolated_pair=(2, 1),
+        (2, 1),
         children=[abjadext.nauert.QGridLeaf(preprolated_duration=abjad.Duration(1, 1))],
     )
     e = abjadext.nauert.QGridContainer(
-        preprolated_pair=(2, 1),
+        (2, 1),
         children=[abjadext.nauert.QGridLeaf(abjad.Duration(2))],
     )
 

--- a/tests/test_QGrid___eq__.py
+++ b/tests/test_QGrid___eq__.py
@@ -12,7 +12,7 @@ def test_QGrid___eq___01():
 def test_QGrid___eq___02():
     a = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_duration=abjad.Duration(1, 1),
+            preprolated_pair=(1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),
@@ -33,7 +33,7 @@ def test_QGrid___eq___02():
     )
     b = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_duration=abjad.Duration(1, 1),
+            preprolated_pair=(1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),
@@ -60,7 +60,7 @@ def test_QGrid___eq___03():
     a = abjadext.nauert.QGrid()
     b = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_duration=abjad.Duration(1, 1),
+            preprolated_pair=(1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),
@@ -84,7 +84,7 @@ def test_QGrid___eq___03():
     d = (
         abjadext.nauert.QGrid(
             root_node=abjadext.nauert.QGridContainer(
-                preprolated_duration=abjad.Duration(1, 1),
+                preprolated_pair=(1, 1),
                 children=[
                     abjadext.nauert.QGridLeaf(
                         preprolated_duration=abjad.Duration(1, 1),

--- a/tests/test_QGrid___eq__.py
+++ b/tests/test_QGrid___eq__.py
@@ -12,7 +12,7 @@ def test_QGrid___eq___01():
 def test_QGrid___eq___02():
     a = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_pair=(1, 1),
+            (1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),
@@ -33,7 +33,7 @@ def test_QGrid___eq___02():
     )
     b = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_pair=(1, 1),
+            (1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),
@@ -60,7 +60,7 @@ def test_QGrid___eq___03():
     a = abjadext.nauert.QGrid()
     b = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_pair=(1, 1),
+            (1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),
@@ -84,7 +84,7 @@ def test_QGrid___eq___03():
     d = (
         abjadext.nauert.QGrid(
             root_node=abjadext.nauert.QGridContainer(
-                preprolated_pair=(1, 1),
+                (1, 1),
                 children=[
                     abjadext.nauert.QGridLeaf(
                         preprolated_duration=abjad.Duration(1, 1),

--- a/tests/test_QGrid_pickle.py
+++ b/tests/test_QGrid_pickle.py
@@ -7,7 +7,7 @@ import abjadext.nauert
 def test_QGrid_pickle_01():
     q_grid = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_pair=(1, 1),
+            (1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),

--- a/tests/test_QGrid_pickle.py
+++ b/tests/test_QGrid_pickle.py
@@ -7,7 +7,7 @@ import abjadext.nauert
 def test_QGrid_pickle_01():
     q_grid = abjadext.nauert.QGrid(
         root_node=abjadext.nauert.QGridContainer(
-            preprolated_duration=abjad.Duration(1, 1),
+            preprolated_pair=(1, 1),
             children=[
                 abjadext.nauert.QGridLeaf(
                     preprolated_duration=abjad.Duration(1, 1),

--- a/tests/test_QGrid_subdivide_leaf.py
+++ b/tests/test_QGrid_subdivide_leaf.py
@@ -19,6 +19,7 @@ def test_QGrid_subdivide_leaf_01():
     assert result == [a, b, c, d]
 
     root_node = abjadext.nauert.QGridContainer(
+        (1, 1),
         children=[
             abjadext.nauert.QGridLeaf(
                 preprolated_duration=abjad.Duration(2, 1), q_event_proxies=[]
@@ -27,6 +28,5 @@ def test_QGrid_subdivide_leaf_01():
                 preprolated_duration=abjad.Duration(3, 1), q_event_proxies=[]
             ),
         ],
-        preprolated_pair=(1, 1),
     )
     assert format(q_grid.root_node) == format(root_node)

--- a/tests/test_QGrid_subdivide_leaf.py
+++ b/tests/test_QGrid_subdivide_leaf.py
@@ -4,7 +4,6 @@ import abjadext.nauert
 
 def test_QGrid_subdivide_leaf_01():
     q_grid = abjadext.nauert.QGrid()
-
     a = abjadext.nauert.QEventProxy(abjadext.nauert.PitchedQEvent(0, [0]), 0)
     b = abjadext.nauert.QEventProxy(
         abjadext.nauert.PitchedQEvent((9, 20), [1]), (9, 20)
@@ -14,13 +13,11 @@ def test_QGrid_subdivide_leaf_01():
         abjadext.nauert.PitchedQEvent((11, 20), [3]), (11, 20)
     )
     e = abjadext.nauert.QEventProxy(abjadext.nauert.PitchedQEvent(1, [4]), 1)
-
     q_grid.leaves[0].q_event_proxies.extend([a, b, c, d])
     q_grid.leaves[1].q_event_proxies.append(e)
-
     result = q_grid.subdivide_leaf(q_grid.leaves[0], (2, 3))
-
     assert result == [a, b, c, d]
+
     root_node = abjadext.nauert.QGridContainer(
         children=[
             abjadext.nauert.QGridLeaf(
@@ -30,6 +27,6 @@ def test_QGrid_subdivide_leaf_01():
                 preprolated_duration=abjad.Duration(3, 1), q_event_proxies=[]
             ),
         ],
-        preprolated_duration=abjad.Duration(1, 1),
+        preprolated_pair=(1, 1),
     )
     assert format(q_grid.root_node) == format(root_node)


### PR DESCRIPTION
See https://github.com/Abjad/abjad/pull/1649

TL;DR rhythm-tree classes now initialize integer pairs, like (1, 2), only; these classes no longer coerce any input.